### PR TITLE
pin AWS provider version to prevent compatibility issues

### DIFF
--- a/ecs/core-infra/versions.tf
+++ b/ecs/core-infra/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0"
+      version = ">= 5.32.0, < 6.0.0"
     }
   }
 }

--- a/ecs/lb-service/versions.tf
+++ b/ecs/lb-service/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46.0"
+      version = ">= 5.46.0, < 6.0.0"
     }
   }
 }


### PR DESCRIPTION
The AWS provider version 6.0 is not backward compatible and causes deprecation warnings and missing property errors. I've fixed the version to avoid these issues.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
